### PR TITLE
Case insensitive ends with on EndsWith

### DIFF
--- a/src/ExcelProvider/ExcelAddressing.fs
+++ b/src/ExcelProvider/ExcelAddressing.fs
@@ -174,7 +174,7 @@ let public openWorkbookView filename range =
         let action = "create ExcelDataReader"
         try          
             let reader =          
-                if filename.EndsWith(".xlsx")
+                if filename.EndsWith(".xlsx", StringComparison.OrdinalIgnoreCase)
                 then Excel.ExcelReaderFactory.CreateOpenXmlReader(stream)
                 else Excel.ExcelReaderFactory.CreateBinaryReader(stream)
 

--- a/tests/ExcelProvider.Tests/ExcelProvider.Tests.fs
+++ b/tests/ExcelProvider.Tests/ExcelProvider.Tests.fs
@@ -12,6 +12,7 @@ type HeaderTest = ExcelFile<"BookTestWithHeader.xls", "A2", true>
 type MultipleRegions = ExcelFile<"MultipleRegions.xlsx", "A1:C5,E3:G5", true>
 type DifferentMainSheet = ExcelFile<"DifferentMainSheet.xlsx">
 type DataTypes = ExcelFile<"DataTypes.xlsx">
+type CaseInsensitive = ExcelFile<"DataTypes.XLSX">
 
 [<Test>]
 let ``Read Text as String``() =
@@ -174,3 +175,11 @@ let ``Can load from multiple ranges``() =
     rows.[3].Fourth |> should equal null
     rows.[3].Fifth |> should equal null
     rows.[3].Sixth |> should equal null
+
+[<Test>]
+let ``Can load file with different casing``() =
+    let file = CaseInsensitive()
+    // just do one of the same tests as was done for the book we are basing this off of
+    let blankRow = file.Data |> Seq.skip 1 |> Seq.head
+    let defaultValue = blankRow.Time
+    defaultValue |> should equal DateTime.MinValue


### PR DESCRIPTION
I ran into an inexplicable `NullReferenceException` when trying to load an XLSX file that I used ".XLSX" in the file path for the `ExcelProvider` constructor. It wasn't until I ran it locally that I discovered the problem was a case sensitive call to `EndsWith()`. This fixes that.