### PR TITLE
Update handling of parameters

### DIFF
--- a/docs/content/getting-started.fsx
+++ b/docs/content/getting-started.fsx
@@ -15,6 +15,26 @@ You can then create a type for an individual workbook. The simplest option is to
 You will then be given typed access to the data held in the first sheet. 
 The first row of the sheet will be treated as field names and the subsequent rows will be treated as values for these fields.
 
+Parameters
+----------
+
+When creating the type you can specify the following parameters:
+
+* `FileName` Location of the Excel file.
+* `SheetName` Name of sheet containing data. Defaults to first sheet.
+* `Range` Specification using `A1:D3` type addresses of one or more ranges. Defaults to use whole sheet.
+* `ForceString` Specifies forcing data to be processed as strings. Defaults to `false`.
+
+All but the first are optional. 
+
+The parameters can be specified by position or by using the name - for example the following are equivalent:
+*)
+
+type MultipleSheets1 = ExcelFile<"MultipleSheets.xlsx", "B">
+type MultipleSheets2 = ExcelFile<"MultipleSheets.xlsx", SheetName="B">
+
+
+(**
 Example
 -------
 

--- a/docs/content/ranges.fsx
+++ b/docs/content/ranges.fsx
@@ -23,7 +23,7 @@ This example demonstrates referencing multiple ranges:
 open FSharp.ExcelProvider
 
 // Let the type provider do it's work
-type MultipleRegions = ExcelFile<"MultipleRegions.xlsx", "A1:C5,E3:G5", true>
+type MultipleRegions = ExcelFile<"MultipleRegions.xlsx", Range="A1:C5,E3:G5", ForceString=true>
 let file = new MultipleRegions()
 let rows = file.Data |> Seq.toArray
 

--- a/src/ExcelProvider/ExcelAddressing.fs
+++ b/src/ExcelProvider/ExcelAddressing.fs
@@ -108,12 +108,12 @@ let getRangeView (workbook : DataSet) range =
     { StartColumn = topLeft.Column; StartRow = topLeft.Row; EndColumn = bottomRight.Column; EndRow = bottomRight.Row; Sheet = sheet }
 
 ///Gets a View object which can be used to read data from the given range in the DataSet
-let public getView (workbook : DataSet) range =
+let public getView (workbook : DataSet) sheetname range =
     let worksheets = workbook.Tables
     
     let workSheetName = 
-        if worksheets.Contains range 
-        then range
+        if worksheets.Contains sheetname 
+        then sheetname
         else worksheets.[0].TableName
 
     let ranges = 
@@ -159,7 +159,7 @@ let getCellValue view row column =
     else null
 
 ///Reads the contents of an excel file into a DataSet
-let public openWorkbookView filename range =
+let public openWorkbookView filename sheetname range =
 
     let fail action (ex : exn) =
         let exceptionTypeName = ex.GetType().Name
@@ -195,4 +195,4 @@ let public openWorkbookView filename range =
         then workbook.Tables.[0].TableName
         else range
 
-    getView workbook range
+    getView workbook sheetname range

--- a/src/ExcelProvider/ExcelProvider.fs
+++ b/src/ExcelProvider/ExcelProvider.fs
@@ -113,11 +113,6 @@ let internal typExcel(cfg:TypeProviderConfig) =
     // Create the main provided type
     let excelFileProvidedType = ProvidedTypeDefinition(executingAssembly, rootNamespace, "ExcelFile", Some(typeof<ExcelFileInternal>))
 
-    // Parameterize the type by the file to use as a template
-    let filename = ProvidedStaticParameter("filename", typeof<string>)
-    let range = ProvidedStaticParameter("sheetname", typeof<string>, "")
-    let forcestring = ProvidedStaticParameter("forcestring", typeof<bool>, false)
-    let staticParams = [ filename; range; forcestring ]
     /// Given a function to format names (such as `niceCamelName` or `nicePascalName`)
     /// returns a name generator that never returns duplicate name (by appending an
     /// index to already used names)

--- a/tests/ExcelProvider.Tests/ExcelProvider.Tests.fs
+++ b/tests/ExcelProvider.Tests/ExcelProvider.Tests.fs
@@ -7,9 +7,9 @@ open FsUnit
 open System
 open System.IO
 
-type BookTest = ExcelFile<"BookTest.xls", "Sheet1", true>
-type HeaderTest = ExcelFile<"BookTestWithHeader.xls", "A2", true>
-type MultipleRegions = ExcelFile<"MultipleRegions.xlsx", "A1:C5,E3:G5", true>
+type BookTest = ExcelFile<"BookTest.xls", "Sheet1", ForceString=true>
+type HeaderTest = ExcelFile<"BookTestWithHeader.xls", Range="A2", ForceString=true>
+type MultipleRegions = ExcelFile<"MultipleRegions.xlsx", Range="A1:C5,E3:G5", ForceString=true>
 type DifferentMainSheet = ExcelFile<"DifferentMainSheet.xlsx">
 type DataTypes = ExcelFile<"DataTypes.xlsx">
 type CaseInsensitive = ExcelFile<"DataTypes.XLSX">
@@ -17,6 +17,7 @@ type MultiLine = ExcelFile<"MultilineHeader.xlsx">
 
 type MultipleSheetsFirst = ExcelFile<"MultipleSheets.xlsx", "A">
 type MultipleSheetsSecond = ExcelFile<"MultipleSheets.xlsx", "B">
+type MultipleSheetsSecondRange = ExcelFile<"MultipleSheets.xlsx", "B", "A2">
 
 [<Test>]
 let ``Read Text as String``() =
@@ -181,7 +182,7 @@ let ``Can load from multiple ranges``() =
     rows.[3].Sixth |> should equal null
 
 [<Test>]
-let ``Can load from first multiple sheets - first``() =
+let ``Can load from multiple sheets - first``() =
     let file = MultipleSheetsFirst()
     let rows = file.Data |> Seq.toArray
 
@@ -194,7 +195,7 @@ let ``Can load from first multiple sheets - first``() =
     rows.[1].Third |> should equal "b"
 
 [<Test>]
-let ``Can load from first multiple sheets - second``() =
+let ``Can load from multiple sheets - second``() =
     let file = MultipleSheetsSecond()
     let rows = file.Data |> Seq.toArray
 
@@ -203,6 +204,13 @@ let ``Can load from first multiple sheets - second``() =
 
     rows.[1].Fourth |> should equal 3.2
     rows.[1].Fifth |> should equal (new DateTime(2013,2,1))
+
+[<Test>]
+let ``Can load from multiple sheets with range``() =
+    let file = MultipleSheetsSecondRange()
+    let rows = file.Data |> Seq.toArray
+
+    rows.[0].``2.2`` |> should equal 3.2
 
 [<Test>]
 let ``Can load file with different casing``() =


### PR DESCRIPTION
* Make treatment in line with CSV Type Provider in F# Data - see [https://github.com/fsharp/FSharp.Data/blob/master/src/Csv/CsvProvider.fs](https://github.com/fsharp/FSharp.Data/blob/master/src/Csv/CsvProvider.fs)
* Clarifies parameter usage and allows use of parameter labels
* Allows SheetName and Range to be used together
* Provides changes needed to support fix for [Issue #15](https://github.com/fsprojects/ExcelProvider/issues/15)
* Added XML Documentation for type
* Updated tests appropriately
* Updated docs appropriately
NOTE - This change will make some existing code no longer work - e.g.
see changes to tests.