### PR TITLE
Support Row.GetValue("column") and handle of out-of-range column indexes explicitly

### DIFF
--- a/docs/content/cells.fsx
+++ b/docs/content/cells.fsx
@@ -28,3 +28,12 @@ let rows = file.Data |> Seq.toArray
 let test = rows.[2].Fourth
 (** And the variable `test` has the following value: *)
 (*** include-value: test ***)
+
+(** Cells can be accessed dynamically using the zero-based column index or case-sensitive header name: *)
+let testByIndex = rows.[2].GetValue 0
+let testByHeader = rows.[2].GetValue "Fourth"
+(** The variables `testByIndex` and `testByHeader` have the respective values: *)
+(*** include-value: testByIndex ***)
+(*** include-value: testByHeader ***)
+
+(** Accessing cell values by index or string header sacrifices type safety; the result signature is `obj`. *)

--- a/tests/ExcelProvider.Tests/ExcelProvider.Tests.fs
+++ b/tests/ExcelProvider.Tests/ExcelProvider.Tests.fs
@@ -5,6 +5,7 @@ open FSharp.ExcelProvider
 open FsUnit
 
 open System
+open System.Collections.Generic
 open System.IO
 
 type BookTest = ExcelFile<"BookTest.xls", "Sheet1", ForceString=true>
@@ -120,6 +121,37 @@ let ``ToString format``() =
     printfn "%O" firstRow
 
     string firstRow |> should equal expectedToString
+
+[<Test>]
+let ``Can get row cell value by column header``() =
+    let file = BookTest()
+    let row = file.Data |> Seq.head
+    row.GetValue "SEC" |> should equal "ASI"
+
+[<Test>]
+let ``GetValue with column header is case-sensitive``() =
+    let file = BookTest()
+    let row = file.Data |> Seq.head
+    row.GetValue "SEC" |> should equal "ASI"
+    (fun () -> row.GetValue "SeC" |> ignore) |> should throw typeof<Exception>
+
+[<Test>]
+let ``GetValue with negative column index should fail``() =
+    let file = BookTest()
+    let row = file.Data |> Seq.head
+    (fun () -> row.GetValue -1 |> ignore) |> should throw typeof<Exception>
+
+[<Test>]
+let ``GetValue with column index out of range should be null`` () =
+    let file = BookTest()
+    let row = file.Data |> Seq.head
+    row.GetValue (Int32.MaxValue) |> should equal null
+
+[<Test>]
+let ``GetValue with nonexistent column header should fail``() =
+    let file = BookTest()
+    let row = file.Data |> Seq.head
+    (fun () -> row.GetValue "bad header" |> ignore) |> should throw typeof<Exception>
 
 [<Test>]
 let ``Can access first row in typed excel data``() =


### PR DESCRIPTION
The goal is to support `row.GetValue "header name"` in the same way that `row.GetValue columnIndex` is currently supported.

I wasn't sure what should happen if an invalid header name was supplied. I wanted to be consistent with an invalid column index being supplied, but found no explicit handling or tests around that scenario. I _did_ find that if a row index was out-of-range, `null` was returned. Based on this, I decided to:
 1. Fail explicitly when a negative column index is supplied,
 2. Return `null` when a positive column index is supplied, but it is outside the range of used columns,
 3. Fail explicitly when a column name (header) is supplied and it does not match an existing column header, and
 4. Implement column-header-lookup in a case-sensitive manner. If a header is not found, perform a case-insensitive key search, solely for the purpose of providing a more helpful message (`Column "foo" was not found. Did you mean "Foo"?`).

Added tests for each of these and updated "cells" doc.