### PR TITLE
add HasHeaders parameter to no-headers doc

### DIFF
--- a/docs/content/headers.fsx
+++ b/docs/content/headers.fsx
@@ -26,7 +26,7 @@ This example shows the use of the type provider in an F# script on a sheet conta
 open FSharp.ExcelProvider
 
 // Let the type provider do it's work
-type DataTypesTest = ExcelFile<"DataTypesNoHeader.xlsx">
+type DataTypesTest = ExcelFile<"DataTypesNoHeader.xlsx", HasHeaders=false>
 let file = new DataTypesTest()
 let row = file.Data |> Seq.head
 let test = row.Column2


### PR DESCRIPTION
On the [Headers](http://fsprojects.github.io/ExcelProvider/headers.html) documentation page the `HasHeaders=false` parameter was missing (in contrast to what the text says). `Row.Column2` is not a valid property then.

I take it `gh-pages` will eventually be updated by you?