### PR TITLE
Clean up created temp folders

### DIFF
--- a/src/ExcelProvider/ExcelAddressing.fs
+++ b/src/ExcelProvider/ExcelAddressing.fs
@@ -199,4 +199,6 @@ let public openWorkbookView filename sheetname range =
         then workbook.Tables.[0].TableName
         else range
 
-    getView workbook sheetname range
+    let view = getView workbook sheetname range
+    (excelReader :> IDisposable).Dispose()
+    view


### PR DESCRIPTION
Internally the ExcelDataReader creates a new folder in the temp directory any time an excel spreadsheet is opened. The ExcelProvider doesn't dispose of the data reader though meaning the temp folders never get deleted (up to 80GB in one case we found). This PR adds a call to Dispose which will internally delete all of the created temp folders.