### PR TITLE
Upgrade to latest TPSDK and fix binding redirects

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
 #### 0.8.2 - 05.16.2017
-* Upgrading ProvidedTypes.fs from FSharp.TypeProviders.StarterPack to fix a Mono5 compatibility issue.
+* Upgrading ProvidedTypes.fs from FSharp.TypeProviders.SDK to fix a Mono5 compatibility issue.
 #### 0.8.1 - 02.02.2017
 * Clean up created temp folders by disposing ExcelDataReader - https://github.com/fsprojects/ExcelProvider/pull/37
 * Upgrade to latest versions of dependencies

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
+#### 0.9.0
+* Upgrading ProvidedTypes.fs to latest FSharp.TypeProviders.SDK for  https://github.com/fsprojects/ExcelProvider/issues/52
+
 #### 0.8.2 - 05.16.2017
 * Upgrading ProvidedTypes.fs from FSharp.TypeProviders.SDK to fix a Mono5 compatibility issue.
+
 #### 0.8.1 - 02.02.2017
 * Clean up created temp folders by disposing ExcelDataReader - https://github.com/fsprojects/ExcelProvider/pull/37
 * Upgrade to latest versions of dependencies

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,16 +1,21 @@
 source https://nuget.org/api/v2
 
-nuget ExcelDataReader
+framework: >= net45
 
-github fsprojects/FSharp.TypeProviders.StarterPack src/ProvidedTypes.fsi
-github fsprojects/FSharp.TypeProviders.StarterPack src/ProvidedTypes.fs
+nuget SharpZipLib
+nuget ExcelDataReader 2.1.2.3
+nuget FSharp.Core 4.1.17
+
+github fsprojects/FSharp.TypeProviders.SDK src/ProvidedTypes.fsi
+github fsprojects/FSharp.TypeProviders.SDK src/ProvidedTypes.fs
 
 group Build
   source https://nuget.org/api/v2
+  framework: net45
 
   nuget SourceLink.Fake
-  nuget FAKE
-  nuget FSharp.Formatting
+  nuget FAKE 4.64.13
+  nuget FSharp.Formatting 2.14.4
 
   github fsharp/FAKE modules/Octokit/Octokit.fsx
 
@@ -18,9 +23,9 @@ group Test
   source https://nuget.org/api/v2
   framework: net461
 
-  nuget NUnit redirects: force
-  nuget NUnit.Console
-  nuget NUnit3TestAdapter version_in_path: true
-  nuget FSharp.Core redirects: force, content: none
+  nuget NUnit 3.6.1
+  nuget NUnit.Console 3.6.1
+  nuget NUnit3TestAdapter 3.7.0 version_in_path: true
+  nuget FSharp.Core 4.3.4
 
   github fsprojects/FsUnit src/FsUnit.NUnit/FsUnit.fs

--- a/paket.lock
+++ b/paket.lock
@@ -1,42 +1,85 @@
+RESTRICTION: >= net45
 NUGET
   remote: https://www.nuget.org/api/v2
     ExcelDataReader (2.1.2.3)
       SharpZipLib (>= 0.86)
-    SharpZipLib (0.86)
+    FSharp.Core (4.1.17)
+      System.Collections (>= 4.0.11) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Console (>= 4.0) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Diagnostics.Debug (>= 4.0.11) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Diagnostics.Tools (>= 4.0.1) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Globalization (>= 4.0.11) - restriction: && (>= net45) (>= netstandard1.6)
+      System.IO (>= 4.1) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Linq (>= 4.1) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Linq.Expressions (>= 4.1) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Linq.Queryable (>= 4.0.1) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Net.Requests (>= 4.0.11) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Reflection (>= 4.1) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Reflection.Extensions (>= 4.0.1) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Resources.ResourceManager (>= 4.0.1) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Runtime (>= 4.1) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Runtime.Extensions (>= 4.1) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Runtime.Numerics (>= 4.0.1) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Text.RegularExpressions (>= 4.1) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Threading (>= 4.0.11) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Threading.Tasks (>= 4.0.11) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Threading.Tasks.Parallel (>= 4.0.1) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Threading.Thread (>= 4.0) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Threading.ThreadPool (>= 4.0.10) - restriction: && (>= net45) (>= netstandard1.6)
+      System.Threading.Timer (>= 4.0.1) - restriction: && (>= net45) (>= netstandard1.6)
+      System.ValueTuple (>= 4.3) - restriction: && (>= net45) (< netstandard1.6)
+    SharpZipLib (1.0)
+    System.Collections (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Console (4.3.1) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Diagnostics.Debug (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Diagnostics.Tools (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Globalization (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.IO (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Linq (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Linq.Expressions (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Linq.Queryable (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Net.Requests (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Reflection (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Reflection.Extensions (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Resources.ResourceManager (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Runtime (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Runtime.Extensions (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Runtime.Numerics (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Text.RegularExpressions (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Threading (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Threading.Tasks (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Threading.Tasks.Parallel (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Threading.Thread (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Threading.ThreadPool (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.Threading.Timer (4.3) - restriction: && (>= net45) (>= netstandard1.6)
+    System.ValueTuple (4.5) - restriction: && (>= net45) (< netstandard1.6)
 GITHUB
-  remote: fsprojects/FSharp.TypeProviders.StarterPack
-    src/ProvidedTypes.fs (1dab4f94411500794342f61f877feab772e5a754)
-    src/ProvidedTypes.fsi (1dab4f94411500794342f61f877feab772e5a754)
+  remote: fsprojects/FSharp.TypeProviders.SDK
+    src/ProvidedTypes.fs (d50b7556cc57c403cd53bd1116027450d60c72db)
+    src/ProvidedTypes.fsi (d50b7556cc57c403cd53bd1116027450d60c72db)
 GROUP Build
+RESTRICTION: == net45
 NUGET
   remote: https://www.nuget.org/api/v2
-    FAKE (4.61.2)
+    FAKE (4.64.13)
     FSharp.Compiler.Service (2.0.0.6)
     FSharp.Formatting (2.14.4)
       FSharp.Compiler.Service (2.0.0.6)
       FSharpVSPowerTools.Core (>= 2.3 < 2.4)
     FSharpVSPowerTools.Core (2.3)
       FSharp.Compiler.Service (>= 2.0.0.3)
-    Microsoft.Bcl (1.1.10) - framework: net10, net11, net20, net30, net35, net40, net40-full
-      Microsoft.Bcl.Build (>= 1.0.14)
-    Microsoft.Bcl.Build (1.0.21) - import_targets: false, framework: net10, net11, net20, net30, net35, net40, net40-full
-    Microsoft.Net.Http (2.2.29) - framework: net10, net11, net20, net30, net35, net40, net40-full
-      Microsoft.Bcl (>= 1.1.10)
-      Microsoft.Bcl.Build (>= 1.0.14)
-    Octokit (0.24)
-      Microsoft.Net.Http  - framework: net10, net11, net20, net30, net35, net40, net40-full
+    Octokit (0.31)
     SourceLink.Fake (1.1)
 GITHUB
   remote: fsharp/FAKE
-    modules/Octokit/Octokit.fsx (43917109af4ef38194d8993215c3e7c862b19d36)
+    modules/Octokit/Octokit.fsx (1fe6a9d37a67c975eb36cbc88b7eab9a098247f1)
       Octokit (>= 0.20)
 GROUP Test
-FRAMEWORK: NET461
+RESTRICTION: == net461
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (4.1.17) - content: none, redirects: force
-      System.ValueTuple (>= 4.3)
-    NUnit (3.6.1) - redirects: force
+    FSharp.Core (4.3.4)
+    NUnit (3.6.1)
     NUnit.Console (3.6.1)
       NUnit.ConsoleRunner (>= 3.6.1)
       NUnit.Extension.NUnitProjectLoader (>= 3.5)
@@ -44,14 +87,13 @@ NUGET
       NUnit.Extension.NUnitV2ResultWriter (>= 3.5)
       NUnit.Extension.TeamCityEventListener (>= 1.0.2)
       NUnit.Extension.VSProjectLoader (>= 3.5)
-    NUnit.ConsoleRunner (3.6.1)
-    NUnit.Extension.NUnitProjectLoader (3.5)
-    NUnit.Extension.NUnitV2Driver (3.6)
-    NUnit.Extension.NUnitV2ResultWriter (3.5)
-    NUnit.Extension.TeamCityEventListener (1.0.2)
-    NUnit.Extension.VSProjectLoader (3.5)
+    NUnit.ConsoleRunner (3.9)
+    NUnit.Extension.NUnitProjectLoader (3.6)
+    NUnit.Extension.NUnitV2Driver (3.7)
+    NUnit.Extension.NUnitV2ResultWriter (3.6)
+    NUnit.Extension.TeamCityEventListener (1.0.4)
+    NUnit.Extension.VSProjectLoader (3.8)
     NUnit3TestAdapter (3.7.0) - version_in_path: true
-    System.ValueTuple (4.3.1) - content: none, redirects: force
 GITHUB
   remote: fsprojects/FsUnit
-    src/FsUnit.NUnit/FsUnit.fs (d2700b69771379e7a28afa0b4e43da57f2da6e9b)
+    src/FsUnit.NUnit/FsUnit.fs (bd259f8dbbb1dc0f4618c5ce211bf144fe01d817)

--- a/src/ExcelProvider/ExcelProvider.fsproj
+++ b/src/ExcelProvider/ExcelProvider.fsproj
@@ -7,13 +7,14 @@
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
     <DocumentationFile>ExcelProvider.XML</DocumentationFile>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.StarterPack\src\ProvidedTypes.fsi">
+    <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.SDK\src\ProvidedTypes.fsi">
       <Paket>True</Paket>
       <Link>paket-files/ProvidedTypes.fsi</Link>
     </Compile>
-    <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.StarterPack\src\ProvidedTypes.fs">
+    <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.SDK\src\ProvidedTypes.fs">
       <Paket>True</Paket>
       <Link>paket-files/ProvidedTypes.fs</Link>
     </Compile>
@@ -21,7 +22,6 @@
     <Compile Include="TypeProviders.Helper.fs" />
     <Compile Include="ExcelAddressing.fs" />
     <Compile Include="ExcelProvider.fs" />
-    <None Include="app.config" />
     <None Include="paket.references" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/src/ExcelProvider/app.config
+++ b/src/ExcelProvider/app.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
-  </startup>
-</configuration>

--- a/src/ExcelProvider/paket.references
+++ b/src/ExcelProvider/paket.references
@@ -1,5 +1,6 @@
 File:ProvidedTypes.fsi
 File:ProvidedTypes.fs
 
+FSharp.Core
 ExcelDataReader
 SharpZipLib

--- a/tests/ExcelProvider.Tests/App.config
+++ b/tests/ExcelProvider.Tests/App.config
@@ -1,19 +1,3 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<runtime><assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-  <dependentAssembly>
-    <Paket>True</Paket>
-    <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.1.0" />
-  </dependentAssembly>
-  <dependentAssembly>
-    <Paket>True</Paket>
-    <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.1.1" />
-  </dependentAssembly>
-  <dependentAssembly>
-    <Paket>True</Paket>
-    <assemblyIdentity name="nunit.framework" publicKeyToken="2638cd05610744eb" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="3.6.1.0" />
-  </dependentAssembly>
-</assemblyBinding></runtime></configuration>
+</configuration>

--- a/tests/ExcelProvider.Tests/ExcelProvider.Tests.fsproj
+++ b/tests/ExcelProvider.Tests/ExcelProvider.Tests.fsproj
@@ -8,6 +8,8 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\paket-files\test\fsprojects\FsUnit\src\FsUnit.NUnit\FsUnit.fs">
@@ -38,6 +40,7 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <ProjectReference Include="..\..\src\ExcelProvider\ExcelProvider.fsproj">
       <Name>ExcelProvider</Name>
       <Project>{7e90d6ce-a10b-4858-a5bc-41df7250cbca}</Project>


### PR DESCRIPTION
* Fixes https://github.com/fsprojects/ExcelProvider/issues/52
* cleans up the generation of binding redirects

Also noticed we should 
* update to latest ExcelDataReader
* remove use of SourceLink (now outdated by SourceLink 2.0)
* target .NET Standard (recent ExcelDataReader do that)
