### PR TITLE
Fix issue #69 - Build.cmd failing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,6 @@ docs/content/release-notes.md
 .fake
 docs/tools/FSharp.Formatting.svclog
 *.bak
+
+# Ionide is a plugin for Fsharp for VSCODE
+.ionide/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ init:
 build_script:
   - cmd: build.cmd
 test: off
-os: Visual Studio 2017
+image: Visual Studio 2019
 version: 0.0.1.{build}
 artifacts:
   - path: bin

--- a/src/ExcelProvider.DesignTime/ExcelProvider.DesignTime.fsproj
+++ b/src/ExcelProvider.DesignTime/ExcelProvider.DesignTime.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;netcoreapp2.0;net45</TargetFrameworks>
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
@@ -24,7 +24,7 @@
     <Compile Include="ExcelProvider.DesignTime.fs" />
     <None Include="paket.references" />
     <None Include="..\..\packages\NetStandard.Library.NetFramework\build\net461\lib\netstandard.dll">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/src/ExcelProvider.Runtime/ExcelProvider.Runtime.fsproj
+++ b/src/ExcelProvider.Runtime/ExcelProvider.Runtime.fsproj
@@ -6,6 +6,7 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0; net45</TargetFrameworks>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
@@ -21,7 +22,7 @@
   </ItemGroup>
 
   <Target Name="BeforeBuild">
-    <MSBuild Projects="..\ExcelProvider.DesignTime\ExcelProvider.DesignTime.fsproj" Targets="Restore"  />
+    <MSBuild Projects="..\ExcelProvider.DesignTime\ExcelProvider.DesignTime.fsproj" Targets="Restore" />
     <MSBuild Projects="..\ExcelProvider.DesignTime\ExcelProvider.DesignTime.fsproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=netcoreapp2.0" />
     <MSBuild Projects="..\ExcelProvider.DesignTime\ExcelProvider.DesignTime.fsproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=netstandard2.0" />
     <MSBuild Projects="..\ExcelProvider.DesignTime\ExcelProvider.DesignTime.fsproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=net45" />


### PR DESCRIPTION
As reported build.cmd was failing on Windows with error FS2026: Deterministic builds only support portable PDB's

This seems to be due to a change in the compiler.  Traditional PDB's are not usable on non-windows platforms, and not well documented.  Portable PDB's can be used on all platforms, so are now required for reproducible builds which can work cross-platform.

I have updated the project files to build portable pdb's, which allows the build process to complete successfully