### PR TITLE
Allow reading Excel files that are currently open

### DIFF
--- a/src/ExcelProvider.Runtime/ExcelProvider.Runtime.fs
+++ b/src/ExcelProvider.Runtime/ExcelProvider.Runtime.fs
@@ -182,7 +182,7 @@ module internal ExcelAddressing =
 
         use stream =
             try
-                File.OpenRead(filename)
+                new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)
             with
             | ex ->
                 let action = sprintf "open file '%s'" filename


### PR DESCRIPTION
This allows to use the type provider while the Excel file is open in Excel 365.
