### PR TITLE
Read from stream

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -359,7 +359,8 @@
               NuspecProperties="$(NuspecProperties)"
               PackageLicenseFile="$(PackageLicenseFile)"
               PackageLicenseExpression="$(PackageLicenseExpression)"
-              PackageLicenseExpressionVersion="$(PackageLicenseExpressionVersion)" />
+              PackageLicenseExpressionVersion="$(PackageLicenseExpressionVersion)"
+              NoDefaultExcludes="$(NoDefaultExcludes)" />
 
     <PackTask Condition="$(UseMSBuild15_9_Pack)"
               PackItem="$(PackProjectInputFile)"

--- a/src/ExcelProvider.DesignTime/ExcelProvider.DesignTime.fs
+++ b/src/ExcelProvider.DesignTime/ExcelProvider.DesignTime.fs
@@ -3,7 +3,7 @@ module FSharp.Interop.Excel.ExcelProvider.ProviderImplementation
 open System
 open System.Collections.Generic
 open System.IO
-
+open FSharp.Interop.Excel
 open FSharp.Interop.Excel.ExcelProvider
 open Microsoft.FSharp.Core.CompilerServices
 open ProviderImplementation.ProvidedTypes

--- a/src/ExcelProvider.DesignTime/ExcelProvider.DesignTime.fs
+++ b/src/ExcelProvider.DesignTime/ExcelProvider.DesignTime.fs
@@ -102,6 +102,13 @@ module internal Helpers =
         match items with
         | [ a; b ] -> func a b
         | _ -> failwith "Expected two item list."
+    
+    // Avoids "warning FS0025: Incomplete pattern matches on this expression"
+    // when using: (fun [row] -> <@@ ... @@>)
+    let threeItemsOrFail func items = 
+        match items with
+        | [ a; b; c ] -> func a b c
+        | _ -> failwith "Expected two item list."
 
     // Avoids "warning FS0025: Incomplete pattern matches on this expression"
     // when using: (fun [] -> <@@ ... @@>)
@@ -223,6 +230,12 @@ type public ExcelProvider(cfg:TypeProviderConfig) as this =
 
              // add a constructor taking the filename and sheetname to load
             providedExcelFileType.AddMember(ProvidedConstructor([ProvidedParameter("filename", typeof<string>); ProvidedParameter("sheetname", typeof<string>)], invokeCode = twoItemsOrFail (fun fileName sheetname -> <@@ ExcelFileInternal(%%fileName, %%sheetname, range, hasheaders) @@>)))
+            
+            // add a constructor taking the stream to load
+            providedExcelFileType.AddMember(ProvidedConstructor([ProvidedParameter("stream", typeof<Stream>); ProvidedParameter("format", typeof<ExcelFormat>)], invokeCode = twoItemsOrFail (fun stream format -> <@@ ExcelFileInternal(%%stream, %%format, sheetname, range, hasheaders) @@>)))
+
+             // add a constructor taking the stream and sheetname to load
+            providedExcelFileType.AddMember(ProvidedConstructor([ProvidedParameter("stream", typeof<Stream>); ProvidedParameter("format", typeof<ExcelFormat>); ProvidedParameter("sheetname", typeof<string>)], invokeCode = threeItemsOrFail (fun stream format sheetname -> <@@ ExcelFileInternal(%%stream, %%format, %%sheetname, range, hasheaders) @@>)))
 
             // add a new, more strongly typed Data property (which uses the existing property at runtime)
             providedExcelFileType.AddMember(ProvidedProperty("Data", typedefof<seq<_>>.MakeGenericType(providedRowType), getterCode = singleItemOrFail (fun excFile -> <@@ (%%excFile:ExcelFileInternal).Data @@>)))

--- a/src/ExcelProvider.DesignTime/ExcelProvider.DesignTime.fsproj
+++ b/src/ExcelProvider.DesignTime/ExcelProvider.DesignTime.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>

--- a/src/ExcelProvider.Runtime/ExcelProvider.Runtime.fs
+++ b/src/ExcelProvider.Runtime/ExcelProvider.Runtime.fs
@@ -1,18 +1,19 @@
-namespace FSharp.Interop.Excel.ExcelProvider
-
-open System
-open System.Collections.Generic
-open System.IO
-open System.Data
-open System.Reflection
-open System.Text.RegularExpressions
-open ExcelDataReader
-open FSharp.Core.CompilerServices
+namespace FSharp.Interop.Excel
 
 type ExcelFormat =
     | Xlsx
     | Csv
     | Binary
+
+namespace FSharp.Interop.Excel.ExcelProvider
+
+open System
+open System.IO
+open System.Data
+open System.Text.RegularExpressions
+open ExcelDataReader
+open FSharp.Core.CompilerServices
+open FSharp.Interop.Excel
 
 [<AutoOpen>]
 module internal ExcelAddressing = 

--- a/src/ExcelProvider.Runtime/ExcelProvider.Runtime.fs
+++ b/src/ExcelProvider.Runtime/ExcelProvider.Runtime.fs
@@ -9,6 +9,11 @@ open System.Text.RegularExpressions
 open ExcelDataReader
 open FSharp.Core.CompilerServices
 
+type ExcelFormat =
+    | Xlsx
+    | Csv
+    | Binary
+
 [<AutoOpen>]
 module internal ExcelAddressing = 
 
@@ -216,6 +221,43 @@ module internal ExcelAddressing =
         (excelReader :> IDisposable).Dispose()
         view
 
+    ///Reads the contents of an excel file into a DataSet
+    let public openWorkbookViewFromStream (stream:Stream, format:ExcelFormat) sheetname range =
+
+#if NETSTANDARD || NETCOREAPP
+        // Register encodings
+        do System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance)
+#endif
+        let fail action (ex : exn) =
+            let exceptionTypeName = ex.GetType().Name
+            let message = sprintf "Could not %s. %s - %s" action exceptionTypeName (ex.Message)
+            failwith message
+        
+        let excelReader =        
+            let action = "create ExcelDataReader"
+            try          
+                let reader =  
+                    match format with
+                    | Xlsx -> ExcelDataReader.ExcelReaderFactory.CreateOpenXmlReader(stream)
+                    | Csv -> ExcelDataReader.ExcelReaderFactory.CreateCsvReader(stream)
+                    | Binary -> ExcelDataReader.ExcelReaderFactory.CreateBinaryReader(stream)
+
+                if reader.IsClosed then fail action (Exception "The reader was closed on startup without raising a specific exception")
+
+                reader
+            with
+            | ex -> fail action ex
+
+        let workbook = excelReader.AsDataSet(new ExcelDataSetConfiguration(ConfigureDataTable = (fun _ -> new ExcelDataTableConfiguration(UseHeaderRow = false))))
+
+        let range =
+            if String.IsNullOrWhiteSpace range
+            then workbook.Tables.[0].TableName
+            else range
+
+        let view = getView workbook sheetname range
+        (excelReader :> IDisposable).Dispose()
+        view
     
     let failInvalidCast (fromType:Type) (toType:Type) columnName rowIndex filename sheetname =
         sprintf
@@ -239,7 +281,7 @@ module internal ExcelAddressing =
                 yield (processedColumnName, columnIndex)]
 
 // Represents a row in a provided ExcelFileInternal
-type Row(filename, sheetname, rowIndex, getCellValue: int -> int -> obj, columns: Map<string, int>) =
+type Row(documentId, sheetname, rowIndex, getCellValue: int -> int -> obj, columns: Map<string, int>) =
     member this.GetValue columnIndex = getCellValue rowIndex columnIndex
 
     member this.GetValue columnName =
@@ -258,13 +300,13 @@ type Row(filename, sheetname, rowIndex, getCellValue: int -> int -> obj, columns
         let value = this.GetValue columnIndex
         try value :?> 'a
         with :? InvalidCastException ->
-            failInvalidCast (value.GetType()) typeof<'a> columnName rowIndex filename sheetname
+            failInvalidCast (value.GetType()) typeof<'a> columnName rowIndex documentId sheetname
 
     member this.TryGetNullableValue<'a when 'a : (new : unit -> 'a) and 'a : struct and 'a :> ValueType> (columnIndex:int) columnName =
         let value = this.GetValue columnIndex
         try (value :?> Nullable<'a>).GetValueOrDefault()
         with :? InvalidCastException ->
-            failInvalidCast (value.GetType()) typeof<'a> columnName rowIndex filename sheetname
+            failInvalidCast (value.GetType()) typeof<'a> columnName rowIndex documentId sheetname
 
     override this.ToString() =
         let columnValueList =
@@ -277,14 +319,21 @@ type Row(filename, sheetname, rowIndex, getCellValue: int -> int -> obj, columns
         sprintf "Row %d%s%s" rowIndex Environment.NewLine columnValueList
 
 // Simple type wrapping Excel data
-type ExcelFileInternal(filename, sheetname, range, hasheaders) =
+type ExcelFileInternal private (view, documentId, sheetname, hasheaders) =
 
     let data =
-        let view = openWorkbookView filename sheetname range
         let columns = [for (columnName, columnIndex) in getColumnDefinitions view hasheaders -> columnName, columnIndex] |> Map.ofList
-        let buildRow rowIndex = new Row(filename, sheetname, rowIndex, getCellValue view, columns)
+        let buildRow rowIndex = new Row(documentId, sheetname, rowIndex, getCellValue view, columns)
         seq{(if hasheaders then 1 else 0) .. view.RowCount}
         |> Seq.map buildRow
+
+    new (filename, sheetname, range, hasheaders) = 
+        let view = openWorkbookView filename sheetname range
+        ExcelFileInternal(view, filename, sheetname, hasheaders)
+
+    new(stream, format, sheetname, range, hasheaders) = 
+        let view = openWorkbookViewFromStream (stream, format) sheetname range
+        ExcelFileInternal(view, "stream", sheetname, hasheaders)
 
     member __.Data = data
 

--- a/src/ExcelProvider.Runtime/ExcelProvider.Runtime.fsproj
+++ b/src/ExcelProvider.Runtime/ExcelProvider.Runtime.fsproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0; net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DebugType>portable</DebugType>
   </PropertyGroup>
@@ -23,22 +23,10 @@
 
   <Target Name="BeforeBuild">
     <MSBuild Projects="..\ExcelProvider.DesignTime\ExcelProvider.DesignTime.fsproj" Targets="Restore" />
-    <MSBuild Projects="..\ExcelProvider.DesignTime\ExcelProvider.DesignTime.fsproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=netcoreapp2.0" />
     <MSBuild Projects="..\ExcelProvider.DesignTime\ExcelProvider.DesignTime.fsproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=netstandard2.0" />
-    <MSBuild Projects="..\ExcelProvider.DesignTime\ExcelProvider.DesignTime.fsproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=net45" />
   </Target>
 
   <Target Name="AfterBuild">
-    <CreateItem Include="..\ExcelProvider.DesignTime\bin\$(Configuration)\netcoreapp2.0\*.dll;..\ExcelProvider.DesignTime\bin\$(Configuration)\netcoreapp2.0\*.pdb">
-      <Output TaskParameter="Include" ItemName="DesignTimeBinaries1" />
-    </CreateItem>
-    <Copy SourceFiles="@(DesignTimeBinaries1)" DestinationFolder="$(OutputPath)/../typeproviders/fsharp41/netcoreapp2.0" />
-
-    <CreateItem Include="..\ExcelProvider.DesignTime\bin\$(Configuration)\net45\*.dll;..\ExcelProvider.DesignTime\bin\$(Configuration)\net45\*.pdb">
-      <Output TaskParameter="Include" ItemName="DesignTimeBinaries2" />
-    </CreateItem>
-    <Copy SourceFiles="@(DesignTimeBinaries2)" DestinationFolder="$(OutputPath)/../typeproviders/fsharp41/net45" />
-
     <CreateItem Include="..\ExcelProvider.DesignTime\bin\$(Configuration)\netstandard2.0\*.dll;..\ExcelProvider.DesignTime\bin\$(Configuration)\netstandard2.0\*.pdb">
       <Output TaskParameter="Include" ItemName="DesignTimeBinaries3" />
     </CreateItem>

--- a/tests/ExcelProvider.Tests/ExcelProvider.Tests.fs
+++ b/tests/ExcelProvider.Tests/ExcelProvider.Tests.fs
@@ -184,6 +184,23 @@ let ``Can load data from spreadsheet``() =
     row.VOL |> should equal "322"
 
 [<Test>]
+let ``Can load data from stream``() =
+    let file = Path.Combine(Environment.CurrentDirectory, "BookTestDifferentData.xls")
+
+    printfn "%s" file
+
+    use stream = new FileStream(file, FileMode.Open)
+    let otherBook = BookTest(stream, ExcelFormat.Binary)
+    let row = otherBook.Data |> Seq.head
+
+    row.SEC |> should equal "TASI"
+    row.STYLE |> should equal "B"
+    row.``STRIKE 1`` |> should equal "3"
+    row.``STRIKE 2`` |> should equal "4"
+    row.``STRIKE 3`` |> should equal "5"
+    row.VOL |> should equal "322"
+
+[<Test>]
 let ``Can load from multiple ranges``() =
     let file = MultipleRegions()
     let rows = file.Data |> Seq.toArray

--- a/tests/ExcelProvider.Tests/ExcelProvider.Tests.fsproj
+++ b/tests/ExcelProvider.Tests/ExcelProvider.Tests.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
@@ -37,6 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0"/>
     <ProjectReference Include="..\..\src\ExcelProvider.Runtime\ExcelProvider.Runtime.fsproj">
       <Name>ExcelProvider.Runtime</Name>


### PR DESCRIPTION
This change allows reading Excel files from stream. In order to support different excel formats (which were previously detected from file extension) a union type has been introduced. 
I added one unit test and tested the new constructor in my local project and it worked fine.

Hint: this change also removed all TargetFrameworks except .NetStandard 2.0 in order to be able to compile in VS2019. Feel free to omit these changes